### PR TITLE
Fix date precision for start and end times

### DIFF
--- a/src/pyorcidator/helper.py
+++ b/src/pyorcidator/helper.py
@@ -338,9 +338,13 @@ def process_affiliation_entries(
             else:
                 logger.warning("ungrounded role: %s", entry.role)
         if entry.start_date:
-            qualifiers.append(DateQualifier.start_time(entry.start_date))
+            qualifiers.append(
+                DateQualifier.start_time(entry.start_date, precision=entry.start_date_precision)
+            )
             if entry.end_date:
-                qualifiers.append(DateQualifier.end_time(entry.end_date))
+                qualifiers.append(
+                    DateQualifier.end_time(entry.end_date, precision=entry.end_date_precision)
+                )
         line = EntityLine(
             subject=subject_qid,
             predicate=property_id,

--- a/tests/test_quickstatements.py
+++ b/tests/test_quickstatements.py
@@ -37,6 +37,25 @@ class TestQuickStatements(unittest.TestCase):
             employment_line.get_line(),
         )
 
+        # Try with different date precision
+        start_date_month = datetime.datetime(year=2021, month=2, day=1)
+        # 10 = month precision
+        start_date_month_qualifier = DateQualifier.start_time(start_date_month, precision=10)
+        employment_line_less_precise = EntityLine(
+            subject=subject_qid,
+            predicate="P108",  # employer
+            target="Q49121",  # Harvard medical school
+            qualifiers=[
+                reference_url_qualifier,
+                start_date_month_qualifier,
+                position_held_qualifier,
+            ],
+        )
+        self.assertEqual(
+            'Q47475003|P108|Q49121|S854|"https://orcid.org/0000-0003-4423-4370"|P580|+2021-02-00T00:00:00Z/10|P39|Q1706722',
+            employment_line_less_precise.get_line(),
+        )
+
         nickname_line = TextLine(
             subject=subject_qid,
             predicate="P1449",


### PR DESCRIPTION
The issue was that the precision value wasn't getting passed to the date qualifier.

This fixes that and adds a test case to ensure it's working now - even though I'm not very familiar with this way of writing test cases.

- fix: Pass precision to DateQualifier
- test: Add test for date with lower precision

- Closes #50
