### PR TITLE
Handle external links with http/https/none

### DIFF
--- a/src/pyorcidator/helper.py
+++ b/src/pyorcidator/helper.py
@@ -35,10 +35,11 @@ EXTERNAL_ID_PROPERTIES = {
     "twitter": "P2002",
     "scopus": "P1153",
 }
+HTTP_REGEX = "(https?:\/\/)?"
 PREFIXES = [
-    ("github", "https://github.com/"),
-    ("twitter", "https://twitter.com/"),
-    ("scopus", "https://www.scopus.com/authid/detail.uri?authorId=")
+    ("github", "github.com/"),
+    ("twitter", "twitter.com/"),
+    ("scopus", "www.scopus.com/authid/detail.uri?authorId=")
     # TODO linkedin, figshare, researchgate, publons, semion, semantic scholar, google scholar, etc.
 ]
 
@@ -52,8 +53,9 @@ def get_external_ids(data) -> Mapping[str, str]:
         # url_name = d["url-name"].lower().replace(" ", "")
         url = d["url"]["value"].rstrip("/")
         for key, url_prefix in PREFIXES:
-            if url.startswith(url_prefix):
-                rv[key] = url[len(url_prefix) :]
+            prefix_w_regex = f"{HTTP_REGEX}{url_prefix}"
+            if re.match(prefix_w_regex, url):
+                rv[key] = re.sub(prefix_w_regex, "", url)
     return rv
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,3 +27,13 @@ def orcid_w_external_links():
     ids = get_external_ids(data)
 
     return ids
+
+
+@pytest.fixture
+def orcid_w_other_external_links():
+    # Useful for testing twitter and github with no https in URL
+    orcid = "0000-0001-7542-0286"  # Egon Willighagen
+    data = get_orcid_data(orcid)
+    ids = get_external_ids(data)
+
+    return ids

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -103,12 +103,14 @@ def test_get_github(orcid_w_external_links):
     assert orcid_w_external_links["github"] == "seljaseppala"
 
 
-def test_get_twitter():
+def test_get_twitter(orcid_w_other_external_links):
     """Test getting a twitter link."""
-    orcid = "0000-0001-7542-0286"  # Egon Willighagen
-    data = get_orcid_data(orcid)
-    ids = get_external_ids(data)
-    assert ids["twitter"] == "egonwillighagen"
+    assert orcid_w_other_external_links["twitter"] == "egonwillighagen"
+
+
+def test_get_github_no_https(orcid_w_other_external_links):
+    """Test getting a github link with no https."""
+    assert orcid_w_other_external_links["github"] == "egonw"
 
 
 def test_get_scopus(orcid_w_external_links):


### PR DESCRIPTION
- Now if the user added an url with http, https or neither of them,
  pyorcidator still recognizes the URL.

- Closes #53

- refactor: Handle http/https with external urls
- test: Test when external link has no https
